### PR TITLE
feat: add source notice header to style guide contents

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ build
 node_modules
 
 pnpm-lock.yaml
+CHANGELOG.md

--- a/src/guides/angular.test.ts
+++ b/src/guides/angular.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AngularStyleGuide } from './angular';
+
+const mockMarkdown = '# Angular Guide\n\nSome content.';
+const ANGULAR_STYLE_GUIDE_URL =
+  'https://raw.githubusercontent.com/angular/angular/refs/heads/main/adev/src/content/best-practices/style-guide.md';
+
+describe('AngularStyleGuide', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+  });
+
+  describe('fetchStyleGuideMarkdown', () => {
+    it('should fetch and return markdown', async () => {
+      const styleGuide = new AngularStyleGuide();
+      const mockResponse = {
+        ok: true,
+        text: vi.fn().mockResolvedValue(mockMarkdown),
+      };
+      (global.fetch as any) = vi.fn().mockResolvedValue(mockResponse);
+      const result = await styleGuide.fetchStyleGuideMarkdown();
+      expect(global.fetch).toHaveBeenCalledWith(ANGULAR_STYLE_GUIDE_URL);
+      expect(mockResponse.text).toHaveBeenCalled();
+      expect(result).toBe(mockMarkdown);
+    });
+
+    it('should throw error when fetch fails', async () => {
+      const styleGuide = new AngularStyleGuide();
+      (global.fetch as any) = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+      await expect(styleGuide.fetchStyleGuideMarkdown()).rejects.toThrow(
+        'Failed to fetch the style guide.',
+      );
+    });
+
+    it('should throw error when response is not ok', async () => {
+      const styleGuide = new AngularStyleGuide();
+      const mockResponse = { ok: false, status: 404, text: vi.fn() };
+      (global.fetch as any) = vi.fn().mockResolvedValue(mockResponse);
+      await expect(styleGuide.fetchStyleGuideMarkdown()).rejects.toThrow(
+        'Failed to fetch the style guide.',
+      );
+    });
+
+    it('should return cached markdown if available', async () => {
+      const styleGuide = new AngularStyleGuide();
+      (styleGuide as any).markdownCache = mockMarkdown;
+      const result = await styleGuide.fetchStyleGuideMarkdown();
+      expect(result).toBe(mockMarkdown);
+    });
+
+    it('should bypass cache if force is true', async () => {
+      const styleGuide = new AngularStyleGuide();
+      const mockResponse = {
+        ok: true,
+        text: vi.fn().mockResolvedValue(mockMarkdown),
+      };
+      (global.fetch as any) = vi.fn().mockResolvedValue(mockResponse);
+      (styleGuide as any).markdownCache = 'old';
+      const result = await styleGuide.fetchStyleGuideMarkdown(true);
+      expect(result).toBe(mockMarkdown);
+      expect(global.fetch).toHaveBeenCalledWith(ANGULAR_STYLE_GUIDE_URL);
+    });
+  });
+
+  describe('getContent', () => {
+    it('should return the markdown content from the first heading with source header', async () => {
+      const styleGuide = new AngularStyleGuide();
+      vi.spyOn(styleGuide, 'fetchStyleGuideMarkdown').mockResolvedValue(
+        'text before\n# Heading\ncontent',
+      );
+      const result = await styleGuide.getContent();
+      expect(result.startsWith('<!-- source:')).toBe(true);
+      expect(result).toContain('# Heading\ncontent');
+    });
+
+    it('should return all markdown with source header if no heading found', async () => {
+      const styleGuide = new AngularStyleGuide();
+      vi.spyOn(styleGuide, 'fetchStyleGuideMarkdown').mockResolvedValue(
+        'no heading here',
+      );
+      const result = await styleGuide.getContent();
+      expect(result.startsWith('<!-- source:')).toBe(true);
+      expect(result).toContain('no heading here');
+    });
+
+    it('should throw error when fetch fails', async () => {
+      const styleGuide = new AngularStyleGuide();
+      vi.spyOn(styleGuide, 'fetchStyleGuideMarkdown').mockRejectedValue(
+        new Error('Failed to fetch'),
+      );
+      await expect(styleGuide.getContent()).rejects.toThrow(
+        'Failed to fetch the style guide.',
+      );
+    });
+  });
+});

--- a/src/guides/angular.ts
+++ b/src/guides/angular.ts
@@ -48,9 +48,12 @@ export class AngularStyleGuide {
     try {
       const markdown = await this.fetchStyleGuideMarkdown();
       const firstHeadingIndex = markdown.indexOf('#');
-      return firstHeadingIndex !== -1
-        ? markdown.substring(firstHeadingIndex)
-        : markdown;
+      const header = `<!-- source: ${ANGULAR_STYLE_GUIDE_URL} -->\n`;
+      const content =
+        firstHeadingIndex !== -1
+          ? markdown.substring(firstHeadingIndex)
+          : markdown;
+      return header + content;
     } catch (error) {
       throw new Error('Failed to fetch the style guide.', {
         cause: error,

--- a/src/guides/typescript.test.ts
+++ b/src/guides/typescript.test.ts
@@ -67,10 +67,11 @@ describe('TypeScriptStyleGuide', () => {
     });
   });
 
-  describe('getStyleGuide', () => {
+  describe('getContent', () => {
     it('should return the style guide markdown for typescript', async () => {
       const styleGuide = new TypeScriptStyleGuide();
-      const mockMarkdown = '# Google TypeScript Style Guide\n...';
+      const mockMarkdown =
+        '<!-- source: https://raw.githubusercontent.com/google/styleguide/refs/heads/gh-pages/tsguide.html -->\n\n# Google TypeScript Style Guide\n...';
       vi.spyOn(styleGuide, 'fetchStyleGuideMarkdown').mockResolvedValue(
         mockMarkdown,
       );

--- a/src/guides/typescript.ts
+++ b/src/guides/typescript.ts
@@ -52,9 +52,12 @@ export class TypeScriptStyleGuide {
     try {
       const markdown = await this.fetchStyleGuideMarkdown();
       const firstHeadingIndex = markdown.indexOf('#');
-      return firstHeadingIndex !== -1
-        ? markdown.substring(firstHeadingIndex)
-        : markdown;
+      const header = `<!-- source: ${STYLE_GUIDE_URL} -->\n\n`;
+      const content =
+        firstHeadingIndex !== -1
+          ? markdown.substring(firstHeadingIndex)
+          : markdown;
+      return header + content;
     } catch (error) {
       throw new Error('Failed to fetch the style guide.', {
         cause: error,


### PR DESCRIPTION
This pull request includes changes to improve the handling of style guide markdown fetching and content extraction for Angular and TypeScript style guides. The most important changes include adding tests for the Angular style guide, modifying the `getContent` method to include a source header, and updating test descriptions for consistency.

### Improvements to Angular style guide:

* [`src/guides/angular.test.ts`](diffhunk://#diff-68d0f76d883fcab07cb40fdec3610ff70aad1365c3bdde68493ce6b12fdcdd4fR1-R99): Added comprehensive tests for the `AngularStyleGuide` class, including tests for fetching markdown, handling errors, caching, and extracting content.
* [`src/guides/angular.ts`](diffhunk://#diff-bfe4954ddbc49c30d8719b577693fe98e598c603ee27713ff76035b23a9c520aL51-R56): Modified the `getContent` method to include a source header in the returned markdown content.

### Improvements to TypeScript style guide:

* [`src/guides/typescript.test.ts`](diffhunk://#diff-49f8eafa3a76ba9cd6cb2b8a52ab914779f3125dffca93f348297562e3e78a81L70-R74): Updated test descriptions to use `getContent` instead of `getStyleGuide` for consistency.
* [`src/guides/typescript.ts`](diffhunk://#diff-54e0c8c5ace8e36b75236b31318c0058a78ac36f4c7335a768752f3bf76787c7L55-R60): Modified the `getContent` method to include a source header in the returned markdown content.

### Build configuration:

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R6): Added `CHANGELOG.md` to the ignore list to prevent formatting changes in this file.